### PR TITLE
Change home and one login links and refactor

### DIFF
--- a/app/views/identity/pyi/v9/address-check.html
+++ b/app/views/identity/pyi/v9/address-check.html
@@ -1,31 +1,7 @@
-{% extends "layouts/main.html" %}
-
-{% block pageTitle %}
-  GOV.UK page template – {{ serviceName }} – GOV.UK Prototype Kit
-  
-{% endblock %}
-
-{% block header %}
-  {{ govukOneLoginServiceHeader({
-  }) }}
-{% endblock %}
-
-{% block beforeContent %}
-<div class="govuk-phase-banner">
-  <p class="govuk-phase-banner__content">
-    <strong class="govuk-tag govuk-phase-banner__content__tag">
-      Beta
-    </strong>
-    <span class="govuk-phase-banner__text">
-      This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.
-    </span>
-  </p>
-</div>
-{% endblock %}
+{% extends "layouts/cross-service-header.html" %}
+{% set serviceName = nil %}
 
 {% block content %}
-
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 

--- a/app/views/identity/pyi/v9/enter-address.html
+++ b/app/views/identity/pyi/v9/enter-address.html
@@ -1,28 +1,8 @@
-{% extends "layouts/main.html" %}
-
-{% block pageTitle %}
-  GOV.UK page template – {{ serviceName }} – GOV.UK Prototype Kit
-  
-{% endblock %}
-
-{% block header %}
-  {{ govukOneLoginServiceHeader({
-  }) }}
-{% endblock %}
-
-{% block beforeContent %}
+{% extends "layouts/cross-service-header.html" %}
+{% set serviceName = nil %}
 
 
-<div class="govuk-phase-banner">
-  <p class="govuk-phase-banner__content">
-    <strong class="govuk-tag govuk-phase-banner__content__tag">
-      Beta
-    </strong>
-    <span class="govuk-phase-banner__text">
-      This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.
-    </span>
-  </p>
-</div>
+{% block content %}
 <a class="govuk-back-link" href="address-picker-current">Back</a>
 
 

--- a/app/views/identity/pyi/v9/fraud-check.html
+++ b/app/views/identity/pyi/v9/fraud-check.html
@@ -1,15 +1,8 @@
-{% extends "layouts/main.html" %}
+{% extends "layouts/cross-service-header.html" %}
+{% set serviceName = nil %}
 
-{% block pageTitle %}
-  GOV.UK page template – {{ serviceName }} – GOV.UK Prototype Kit
-  
+{% block beforeContent %}
 {% endblock %}
-
-{% block header %}
-  {{ govukOneLoginServiceHeader({
-  }) }}
-{% endblock %}
-
 {% block content %}
 
 <div class="govuk-grid-row">

--- a/app/views/identity/pyi/v9/how-to-pyi.html
+++ b/app/views/identity/pyi/v9/how-to-pyi.html
@@ -1,15 +1,8 @@
-{% extends "layouts/main.html" %}
+{% extends "layouts/cross-service-header.html" %}
+{% set serviceName = nil %}
 
-{% block pageTitle %}
-  GOV.UK page template – {{ serviceName }} – GOV.UK Prototype Kit
-  
+{% block beforeContent %}
 {% endblock %}
-
-{% block header %}
-  {{ govukOneLoginServiceHeader({
-  }) }}
-{% endblock %}
-
 {% block content %}
 
 <div class="govuk-grid-row">

--- a/app/views/identity/pyi/v9/identity-proved.html
+++ b/app/views/identity/pyi/v9/identity-proved.html
@@ -1,27 +1,5 @@
-{% extends "layouts/main.html" %}
-
-{% block pageTitle %}
-  GOV.UK page template – {{ serviceName }} – GOV.UK Prototype Kit
-  
-{% endblock %}
-
-{% block header %}
-  {{ govukOneLoginServiceHeader({
-  }) }}
-{% endblock %}
-
-{% block beforeContent %}
-<div class="govuk-phase-banner">
-  <p class="govuk-phase-banner__content">
-    <strong class="govuk-tag govuk-phase-banner__content__tag">
-      Beta
-    </strong>
-    <span class="govuk-phase-banner__text">
-      This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.
-    </span>
-  </p>
-</div>
-{% endblock %}
+{% extends "layouts/cross-service-header.html" %}
+{% set serviceName = nil %}
 
 {% block content %}
 

--- a/app/views/identity/pyi/v9/kbv-question-1.html
+++ b/app/views/identity/pyi/v9/kbv-question-1.html
@@ -1,27 +1,5 @@
-{% extends "layouts/main.html" %}
-
-{% block pageTitle %}
-  GOV.UK page template – {{ serviceName }} – GOV.UK Prototype Kit
-  
-{% endblock %}
-
-{% block header %}
-  {{ govukOneLoginServiceHeader({
-  }) }}
-{% endblock %}
-
-{% block beforeContent %}
-<div class="govuk-phase-banner">
-  <p class="govuk-phase-banner__content">
-    <strong class="govuk-tag govuk-phase-banner__content__tag">
-      Beta
-    </strong>
-    <span class="govuk-phase-banner__text">
-      This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.
-    </span>
-  </p>
-</div>
-{% endblock %}
+{% extends "layouts/cross-service-header.html" %}
+{% set serviceName = nil %}
 
 {% block content %}
 

--- a/app/views/identity/pyi/v9/kbv-question-2.html
+++ b/app/views/identity/pyi/v9/kbv-question-2.html
@@ -1,7 +1,7 @@
-{% extends "layouts/main.html" %}
+{% extends "layouts/cross-service-header.html" %}
+{% set serviceName = nil %}
 
-{% block pageTitle %}
-  GOV.UK page template – {{ serviceName }} – GOV.UK Prototype Kit
+{% block beforeContent %}
 {% endblock %}
 
 {% block content %}

--- a/app/views/identity/pyi/v9/kbv-question-3.html
+++ b/app/views/identity/pyi/v9/kbv-question-3.html
@@ -1,26 +1,7 @@
-{% extends "layouts/main.html" %}
-
-{% block pageTitle %}
-  GOV.UK page template – {{ serviceName }} – GOV.UK Prototype Kit
-  
-{% endblock %}
-
-{% block header %}
-  {{ govukOneLoginServiceHeader({
-  }) }}
-{% endblock %}
+{% extends "layouts/cross-service-header.html" %}
+{% set serviceName = nil %}
 
 {% block beforeContent %}
-<div class="govuk-phase-banner">
-  <p class="govuk-phase-banner__content">
-    <strong class="govuk-tag govuk-phase-banner__content__tag">
-      Beta
-    </strong>
-    <span class="govuk-phase-banner__text">
-      This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.
-    </span>
-  </p>
-</div>
 {% endblock %}
 
 {% block content %}

--- a/app/views/identity/pyi/v9/kbv-question-4.html
+++ b/app/views/identity/pyi/v9/kbv-question-4.html
@@ -1,13 +1,7 @@
-{% extends "layouts/main.html" %}
+{% extends "layouts/cross-service-header.html" %}
+{% set serviceName = nil %}
 
-{% block pageTitle %}
-  GOV.UK page template – {{ serviceName }} – GOV.UK Prototype Kit
-  
-{% endblock %}
-
-{% block header %}
-  {{ govukOneLoginServiceHeader({
-  }) }}
+{% block beforeContent %}
 {% endblock %}
 
 {% block content %}

--- a/app/views/identity/pyi/v9/kbv-start.html
+++ b/app/views/identity/pyi/v9/kbv-start.html
@@ -1,15 +1,8 @@
-{% extends "layouts/main.html" %}
+{% extends "layouts/cross-service-header.html" %}
+{% set serviceName = nil %}
 
-{% block pageTitle %}
-  GOV.UK page template – {{ serviceName }} – GOV.UK Prototype Kit
-  
+{% block beforeContent %}
 {% endblock %}
-
-{% block header %}
-  {{ govukOneLoginServiceHeader({
-  }) }}
-{% endblock %}
-
 {% block content %}
 
   <div class="govuk-grid-row">

--- a/app/views/identity/pyi/v9/passport-details.html
+++ b/app/views/identity/pyi/v9/passport-details.html
@@ -1,27 +1,8 @@
-{% extends "layouts/main.html" %}
+{% extends "layouts/cross-service-header.html" %}
+{% set serviceName = nil %}
 
-{% block pageTitle %}
-  GOV.UK page template – {{ serviceName }} – GOV.UK Prototype Kit
-  
+{% block beforeContent %}
 {% endblock %}
-
-{% block header %}
-  {{ govukOneLoginServiceHeader({
-  }) }}
-{% endblock %}
-
-<div class="govuk-phase-banner">
-  <p class="govuk-phase-banner__content">
-    <strong class="govuk-tag govuk-phase-banner__content__tag">
-      Beta
-    </strong>
-    <span class="govuk-phase-banner__text">
-      This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.
-    </span>
-  </p>
-</div>
-
-  <a class="govuk-back-link" href="start">Back</a>
 
 {% block content %}
 

--- a/app/views/identity/pyi/v9/pta-setup.html
+++ b/app/views/identity/pyi/v9/pta-setup.html
@@ -1,16 +1,8 @@
-{% extends "layouts/main.html" %}
+{% extends "layouts/cross-service-header.html" %}
+{% set serviceName = nil %}
 
-{% block pageTitle %}
-  GOV.UK page template – {{ serviceName }} – GOV.UK Prototype Kit
-  
+{% block beforeContent %}
 {% endblock %}
-
-{% block header %}
-  {{ govukOneLoginServiceHeader({
-  }) }}
-{% endblock %}
-
-
 {% block content %}
 
 <div class="govuk-grid-row">

--- a/app/views/identity/pyi/v9/pyi-online.html
+++ b/app/views/identity/pyi/v9/pyi-online.html
@@ -1,13 +1,7 @@
-{% extends "layouts/main.html" %}
+{% extends "layouts/cross-service-header.html" %}
+{% set serviceName = nil %}
 
-{% block pageTitle %}
-  GOV.UK page template – {{ serviceName }} – GOV.UK Prototype Kit
-  
-{% endblock %}
-
-{% block header %}
-  {{ govukOneLoginServiceHeader({
-  }) }}
+{% block beforeContent %}
 {% endblock %}
 
 {% block content %}

--- a/app/views/identity/pyi/v9/share-id-info.html
+++ b/app/views/identity/pyi/v9/share-id-info.html
@@ -1,16 +1,8 @@
-{% extends "layouts/main.html" %}
+{% extends "layouts/cross-service-header.html" %}
+{% set serviceName = nil %}
 
-{% block pageTitle %}
-  GOV.UK page template – {{ serviceName }} – GOV.UK Prototype Kit
-  
+{% block beforeContent %}
 {% endblock %}
-
-{% block header %}
-  {{ govukOneLoginServiceHeader({
-  }) }}
-{% endblock %}
-
-
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/identity/pyi/v9/share-proof-of-id.html
+++ b/app/views/identity/pyi/v9/share-proof-of-id.html
@@ -1,13 +1,7 @@
-{% extends "layouts/main.html" %}
+{% extends "layouts/cross-service-header.html" %}
+{% set serviceName = nil %}
 
-{% block pageTitle %}
-  GOV.UK page template – {{ serviceName }} – GOV.UK Prototype Kit
-  
-{% endblock %}
-
-{% block header %}
-  {{ govukOneLoginServiceHeader({
-  }) }}
+{% block beforeContent %}
 {% endblock %}
 
 {% block content %}

--- a/app/views/identity/pyi/v9/update-form.html
+++ b/app/views/identity/pyi/v9/update-form.html
@@ -1,15 +1,8 @@
-{% extends "layouts/main.html" %}
+{% extends "layouts/cross-service-header.html" %}
+{% set serviceName = nil %}
 
-{% block pageTitle %}
-  GOV.UK page template – {{ serviceName }} – GOV.UK Prototype Kit
-  
+{% block beforeContent %}
 {% endblock %}
-
-{% block header %}
-  {{ govukOneLoginServiceHeader({
-  }) }}
-{% endblock %}
-
 
 {% block content %}
 

--- a/app/views/identity/pyi/v9/update-your-name-q.html
+++ b/app/views/identity/pyi/v9/update-your-name-q.html
@@ -1,15 +1,8 @@
-{% extends "layouts/main.html" %}
+{% extends "layouts/cross-service-header.html" %}
+{% set serviceName = nil %}
 
-{% block pageTitle %}
-  GOV.UK page template – {{ serviceName }} – GOV.UK Prototype Kit
-  
+{% block beforeContent %}
 {% endblock %}
-
-{% block header %}
-  {{ govukOneLoginServiceHeader({
-  }) }}
-{% endblock %}
-
 
 {% block content %}
 <div class="govuk-grid-row">

--- a/app/views/layouts/cross-service-header.html
+++ b/app/views/layouts/cross-service-header.html
@@ -1,0 +1,18 @@
+{% extends "di-govuk-one-login-service-header/layouts/service-header.html" %}
+
+{% set homepageLink = '/identity/task-page.html' %}
+{% set oneLoginLink = '/identity/one-login-home/v9/one-login-homepage.html' %}
+
+
+{% block beforeContent %}
+<div class="govuk-phase-banner">
+  <p class="govuk-phase-banner__content">
+    <strong class="govuk-tag govuk-phase-banner__content__tag">
+      Beta
+    </strong>
+    <span class="govuk-phase-banner__text">
+      This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.
+    </span>
+  </p>
+</div>
+{% endblock %}

--- a/app/views/services/dbs/apply-for-dbs-check.html
+++ b/app/views/services/dbs/apply-for-dbs-check.html
@@ -1,14 +1,9 @@
-{% extends "layouts/main.html" %}
+{% extends "layouts/cross-service-header.html" %}
+{% set serviceName =  "Basic criminal record check" %}
 
-{% block pageTitle %}
-  GOV.UK page template – {{ serviceName }} – GOV.UK Prototype Kit
+{% block beforeContent %}
 {% endblock %}
 
-{% block header %}
-  {{ govukOneLoginServiceHeader({
-    serviceName: "Basic criminal record check"
-  }) }}
-{% endblock %}
 
 {% block content %}
 

--- a/app/views/services/pta/what-is-your-ni.html
+++ b/app/views/services/pta/what-is-your-ni.html
@@ -1,13 +1,7 @@
-{% extends "layouts/main.html" %}
+{% extends "layouts/cross-service-header.html" %}
+{% set serviceName =  "Personal tax account" %}
 
-{% block pageTitle %}
-  GOV.UK page template – {{ serviceName }} – GOV.UK Prototype Kit
-{% endblock %}
-
-{% block header %}
-  {{ govukOneLoginServiceHeader({
-    serviceName: "Personal tax account"
-  }) }}
+{% block beforeContent %}
 {% endblock %}
 
 {% block content %}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "@govuk-prototype-kit/common-templates": "1.2.1",
         "govuk-frontend": "4.7.0",
-        "govuk-one-login-service-header": "github:alphagov/di-govuk-one-login-service-header#prototype-example",
+        "govuk-one-login-service-header": "github:alphagov/di-govuk-one-login-service-header",
         "govuk-prototype-kit": "13.10.0"
       }
     },
@@ -1486,7 +1486,7 @@
     },
     "node_modules/govuk-one-login-service-header": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/alphagov/di-govuk-one-login-service-header.git#b4cd7033738a58a5db870eebc7d390aefce62029",
+      "resolved": "git+ssh://git@github.com/alphagov/di-govuk-one-login-service-header.git#344876bf81b320c8e684ea504e7ba754bc513aa9",
       "license": "ISC",
       "dependencies": {
         "govuk-frontend": "^4.5.0",
@@ -4573,8 +4573,8 @@
       "integrity": "sha512-0OsdCusF5qvLWwKziU8zqxiC0nq6WP0ZQuw51ymZ/1V0tO71oIKMlSLN2S9bm8RcEGSoidPt2A34gKxePrLjvg=="
     },
     "govuk-one-login-service-header": {
-      "version": "git+ssh://git@github.com/alphagov/di-govuk-one-login-service-header.git#b4cd7033738a58a5db870eebc7d390aefce62029",
-      "from": "govuk-one-login-service-header@github:alphagov/di-govuk-one-login-service-header#prototype-example",
+      "version": "git+ssh://git@github.com/alphagov/di-govuk-one-login-service-header.git#344876bf81b320c8e684ea504e7ba754bc513aa9",
+      "from": "govuk-one-login-service-header@alphagov/di-govuk-one-login-service-header",
       "requires": {
         "govuk-frontend": "^4.5.0",
         "nunjucks": "^3.2.4"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@govuk-prototype-kit/common-templates": "1.2.1",
     "govuk-frontend": "4.7.0",
-    "govuk-one-login-service-header": "github:alphagov/di-govuk-one-login-service-header#prototype-example",
+    "govuk-one-login-service-header": "github:alphagov/di-govuk-one-login-service-header",
     "govuk-prototype-kit": "13.10.0"
   }
 }


### PR DESCRIPTION
Create a separate layout for pages using the one login header to reduce repetition in the code.
Configure the homepage link (GOVUK link) and the One Login link to go to pages in the prototype rather than the live govuk page and one login homepage respectively.